### PR TITLE
Don't truncate lecture note title and content

### DIFF
--- a/src/main/resources/view/NoteListCard.fxml
+++ b/src/main/resources/view/NoteListCard.fxml
@@ -18,17 +18,17 @@
             <padding>
                 <Insets top="5" right="5" bottom="5" left="15"/>
             </padding>
-            <HBox spacing="5" alignment="CENTER_LEFT">
+            <HBox spacing="5">
                 <Label fx:id="id" styleClass="cell_big_label">
                     <minWidth>
                         <!-- Ensures that the label text is never truncated -->
                         <Region fx:constant="USE_PREF_SIZE"/>
                     </minWidth>
                 </Label>
-                <Label fx:id="title" text="\$first" styleClass="cell_big_label"/>
+                <Label fx:id="title" text="\$first" styleClass="cell_big_label" wrapText="true"/>
             </HBox>
             <FlowPane fx:id="tags"/>
-            <Label fx:id="content" styleClass="cell_small_label" text="\$content"/>
+            <Label fx:id="content" styleClass="cell_small_label" text="\$content" wrapText="true"/>
         </VBox>
     </GridPane>
 </HBox>


### PR DESCRIPTION
Minor FXML fix, but it shows what FXML parameters can be used.